### PR TITLE
Extracting chapter information from ePUB

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,14 @@ go run .
 
 # TODO
  - [x] Parse ePUB from Golang
- - [x] Organize code a little more
+ - [x] Organize code
  - [x] Add worker pools for batch conversion and less CPU strain
- - [ ] Reduce output audio size
+ - [x] Reduce output audio size
+ - [x] Extract chapter info
+ - [ ] Add more sample ePUBs
+ - [ ] Add automated tests
+ - [ ] Add multiple input (separate output by folder same name as input file)
+ - [ ] Organize the code some more
  - [ ] Support other languages beyond english
  - [ ] Display progress
  - [ ] Add support for Ubuntu TTS

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module epub-tts
 
 go 1.22.0
+
+require golang.org/x/text v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
+golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=

--- a/internal/book/epub.go
+++ b/internal/book/epub.go
@@ -2,9 +2,11 @@ package book
 
 type EpubSection struct {
 	ID          string `json:"id"`
+	Title       string `json:"title"`
 	HtmlContent string `json:"htmlString"`
 }
 
 type Epub struct {
+	Toc      map[string]string
 	Sections []EpubSection
 }

--- a/internal/book/text-book.go
+++ b/internal/book/text-book.go
@@ -1,10 +1,21 @@
 package book
 
-import "epub-tts/internal/str"
+import (
+	"epub-tts/internal/str"
+	"strings"
+)
 
 type Chapter struct {
+	ID      string
 	Name    string
 	Content string
+}
+
+func (c Chapter) NameOrID() string {
+	if c.Name == "" {
+		return c.ID
+	}
+	return c.Name
 }
 
 type TextBook struct {
@@ -15,8 +26,11 @@ func TextBookFromEpub(input Epub) TextBook {
 	chapters := []Chapter{}
 
 	for _, v := range input.Sections {
+		name := str.SanitizeString(v.Title)
+		name = strings.ReplaceAll(name, "\n", "")
 		chapter := Chapter{
-			Name:    str.SanitizeString(v.ID),
+			ID:      str.SanitizeString(v.ID),
+			Name:    name,
 			Content: str.SanitizeString(str.RemoveTags(v.HtmlContent)),
 		}
 		chapters = append(chapters, chapter)

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -4,7 +4,7 @@ const (
 	Perm                = 0777
 	InputFilePath       = "volume/input.epub"
 	OutputFolderName    = "output"
-	TmpOutputFolderName = "output/tmp"
+	TmpOutputFolderName = OutputFolderName + "/tmp"
 	IsDryRun            = false // if true, will generate text files, but not audio files
 	IsDebug             = false // if true, will generate files for section json and html content as well
 )

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -3,6 +3,7 @@ package file
 import (
 	"epub-tts/internal/book"
 	"epub-tts/internal/consts"
+	"epub-tts/internal/str"
 	"errors"
 	"fmt"
 	"os"
@@ -37,22 +38,21 @@ func SaveChapters(textBook book.TextBook) error {
 }
 
 func GetTextfileName(pos int, chapter book.Chapter) string {
-	return GetOutputPath(pos, consts.OutputFolderName, chapter.Name, "txt")
+	return GetOutputPath(pos, consts.OutputFolderName, chapter.NameOrID(), "txt")
 }
 
 func GetTtsAudioFilename(pos int, chapter book.Chapter) string {
-	return GetOutputPath(pos, consts.TmpOutputFolderName, chapter.Name, "aiff")
+	return GetOutputPath(pos, consts.TmpOutputFolderName, chapter.NameOrID(), "aiff")
 }
 
 func GetConvertedAudioFilename(pos int, chapter book.Chapter) string {
-	return GetOutputPath(pos, consts.OutputFolderName, chapter.Name, "mp3")
+	return GetOutputPath(pos, consts.OutputFolderName, chapter.NameOrID(), "mp3")
 }
 
 func GetOutputPath(pos int, outputFolder string, name string, extension string) string {
-	filename := fmt.Sprintf("%d.%s.%s", pos, name, extension)
-	filename = strings.ReplaceAll(filename, " ", "-")
-	filename = strings.ReplaceAll(filename, " ", "-")
+	filename := fmt.Sprintf("%d-%s.%s", pos, name, extension)
 	filename = strings.ToLower(filename)
+	filename = str.CleanFileName(filename)
 
 	filePath := filepath.Join(outputFolder, filename)
 


### PR DESCRIPTION
Adding some attempts to extract chapter title from the ePUB. It's not an straightforward task, but I tried adding some fallbacks to cover a couple of cases. 

If the code can't find the chapter name, it will default to the spine id, just like it was before. Eg, for `3-item5.txt`, which is a text not present in the `Table of Contents`.

| Before | After
| --- | --- |
| ![before](https://github.com/user-attachments/assets/a2c528f9-89ce-42ed-889f-c7046dfed288) | ![after](https://github.com/user-attachments/assets/370fc64b-d566-4f73-b417-551c248e225b) |





